### PR TITLE
[Arch] Add source abstraction layer

### DIFF
--- a/app/src/androidTest/java/com/edipasquale/tdd_room/repository/ImageRepositoryTest.kt
+++ b/app/src/androidTest/java/com/edipasquale/tdd_room/repository/ImageRepositoryTest.kt
@@ -8,9 +8,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.edipasquale.tdd_room.database.ImageDatabase
 import com.edipasquale.tdd_room.dto.Image
 import com.edipasquale.tdd_room.observer.OneTimeObserver
-import com.edipasquale.tdd_room.source.impl.LocalImageSource
-import com.edipasquale.tdd_room.source.impl.NetworkImageSource
-import org.junit.After
+import com.edipasquale.tdd_room.source.impl.RoomImageSource
+import com.edipasquale.tdd_room.source.impl.AsyncTaskImageSource
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -31,8 +30,8 @@ class ImageRepositoryTest {
 
     private lateinit var database: ImageDatabase
     private lateinit var repository: ImageRepository
-    private lateinit var localSource: LocalImageSource
-    private lateinit var networkSource: NetworkImageSource
+    private lateinit var localSource: RoomImageSource
+    private lateinit var networkSource: AsyncTaskImageSource
 
     @Before
     fun setup() {
@@ -44,12 +43,12 @@ class ImageRepositoryTest {
         ).build()
 
         localSource = spy(
-            LocalImageSource(
+            RoomImageSource(
                 database.getImageDao(),
                 ApplicationProvider.getApplicationContext()
             )
         )
-        networkSource = spy(NetworkImageSource())
+        networkSource = spy(AsyncTaskImageSource())
 
         repository = ImageRepository(localSource, networkSource)
     }

--- a/app/src/main/java/com/edipasquale/tdd_room/dagger/RoomModule.kt
+++ b/app/src/main/java/com/edipasquale/tdd_room/dagger/RoomModule.kt
@@ -5,8 +5,8 @@ import androidx.room.Room
 import com.edipasquale.tdd_room.RoomApplication
 import com.edipasquale.tdd_room.database.ImageDatabase
 import com.edipasquale.tdd_room.repository.ImageRepository
-import com.edipasquale.tdd_room.source.impl.LocalImageSource
-import com.edipasquale.tdd_room.source.impl.NetworkImageSource
+import com.edipasquale.tdd_room.source.impl.RoomImageSource
+import com.edipasquale.tdd_room.source.impl.AsyncTaskImageSource
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -17,13 +17,13 @@ class RoomModule(private val app: RoomApplication) {
 
     @Provides
     fun provideLocalSource(database: ImageDatabase, context: Context) =
-        LocalImageSource(database.getImageDao(), context)
+        RoomImageSource(database.getImageDao(), context)
 
     @Provides
-    fun provideNetworkSource() = NetworkImageSource()
+    fun provideNetworkSource() = AsyncTaskImageSource()
 
     @Provides
-    fun provideImageRepository(localSource: LocalImageSource, source: NetworkImageSource) =
+    fun provideImageRepository(localSource: RoomImageSource, source: AsyncTaskImageSource) =
         ImageRepository(localSource, source)
 
     @Provides

--- a/app/src/main/java/com/edipasquale/tdd_room/repository/ImageRepository.kt
+++ b/app/src/main/java/com/edipasquale/tdd_room/repository/ImageRepository.kt
@@ -8,8 +8,8 @@ import com.edipasquale.tdd_room.dto.Image
 import com.edipasquale.tdd_room.model.ImageLibraryErrorModel
 import com.edipasquale.tdd_room.model.ImageLibraryModel
 import com.edipasquale.tdd_room.model.ImageModel
-import com.edipasquale.tdd_room.source.impl.LocalImageSource
-import com.edipasquale.tdd_room.source.impl.NetworkImageSource
+import com.edipasquale.tdd_room.source.LocalImageSource
+import com.edipasquale.tdd_room.source.NetworkImageSource
 
 open class ImageRepository(
     private val localSource: LocalImageSource,
@@ -34,7 +34,12 @@ open class ImageRepository(
 
                 when (networkResponse) {
                     is Either.Data -> {
-                        localSource.saveImage(networkResponse.data)
+                        Transformations.map(localSource.saveImage(networkResponse.data)) { imageSavingResult ->
+                            when (imageSavingResult) {
+                                is Either.Data -> ImageModel(image = imageSavingResult.data)
+                                is Either.Error -> ImageModel(error = imageSavingResult.error)
+                            }
+                        }
                     }
 
                     is Either.Error -> {

--- a/app/src/main/java/com/edipasquale/tdd_room/source/LocalImageSource.kt
+++ b/app/src/main/java/com/edipasquale/tdd_room/source/LocalImageSource.kt
@@ -1,0 +1,32 @@
+package com.edipasquale.tdd_room.source
+
+import androidx.lifecycle.LiveData
+import com.edipasquale.tdd_room.dto.Either
+import com.edipasquale.tdd_room.dto.Image
+
+/**
+ * Local source is intended to save and fetch data from the device, without requiring internet
+ * connection.
+ */
+interface LocalImageSource {
+
+    /**
+     * Fetch the image from a local source
+     */
+    fun fetchImage(url: String): LiveData<Either<Image, Int>>
+
+    /**
+     * Save the image into a local source
+     */
+    fun saveImage(image: Image): LiveData<Either<Image, Int>>
+
+    /**
+     * Fetch all the images saved on the local source
+     */
+    fun getLibrary(query: String?): LiveData<Either<List<Image>, Int>>
+
+    /**
+     * Delete an image from the local source
+     */
+    fun deleteImage(image: Image): LiveData<Either<List<Image>, Int>>
+}

--- a/app/src/main/java/com/edipasquale/tdd_room/source/NetworkImageSource.kt
+++ b/app/src/main/java/com/edipasquale/tdd_room/source/NetworkImageSource.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import com.edipasquale.tdd_room.dto.Either
 import com.edipasquale.tdd_room.dto.Image
 
-interface ImageSource {
+interface NetworkImageSource {
+
     fun fetchImage(url: String): LiveData<Either<Image, Int>>
 }

--- a/app/src/main/java/com/edipasquale/tdd_room/source/impl/AsyncTaskImageSource.kt
+++ b/app/src/main/java/com/edipasquale/tdd_room/source/impl/AsyncTaskImageSource.kt
@@ -8,12 +8,12 @@ import androidx.lifecycle.MutableLiveData
 import com.edipasquale.tdd_room.dto.Either
 import com.edipasquale.tdd_room.dto.Image
 import com.edipasquale.tdd_room.model.ERROR_DOWNLOADING_IMAGE
-import com.edipasquale.tdd_room.source.ImageSource
+import com.edipasquale.tdd_room.source.NetworkImageSource
 import java.io.BufferedInputStream
 import java.io.IOException
 import java.net.URL
 
-open class NetworkImageSource : ImageSource {
+open class AsyncTaskImageSource : NetworkImageSource {
 
     override fun fetchImage(url: String): LiveData<Either<Image, Int>> {
         val liveData = MutableLiveData<Either<Image, Int>>()

--- a/app/src/main/java/com/edipasquale/tdd_room/source/impl/RoomImageSource.kt
+++ b/app/src/main/java/com/edipasquale/tdd_room/source/impl/RoomImageSource.kt
@@ -8,14 +8,14 @@ import com.edipasquale.tdd_room.dto.Either
 import com.edipasquale.tdd_room.dto.Image
 import com.edipasquale.tdd_room.model.ERROR_INTERNAL_STORAGE
 import com.edipasquale.tdd_room.model.ERROR_NOT_FOUND
-import com.edipasquale.tdd_room.model.ImageModel
-import com.edipasquale.tdd_room.source.ImageSource
+import com.edipasquale.tdd_room.source.LocalImageSource
 import com.edipasquale.tdd_room.util.MediaStoreUtil
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 
-open class LocalImageSource(private val imageDao: ImageDao, private val context: Context) : ImageSource {
+open class RoomImageSource(private val imageDao: ImageDao, private val context: Context) :
+    LocalImageSource {
 
     override fun fetchImage(url: String): LiveData<Either<Image, Int>> {
         val liveData = MutableLiveData<Either<Image, Int>>()
@@ -27,8 +27,8 @@ open class LocalImageSource(private val imageDao: ImageDao, private val context:
         return liveData
     }
 
-    fun saveImage(image: Image): LiveData<ImageModel> {
-        val liveData = MutableLiveData<ImageModel>()
+    override fun saveImage(image: Image): LiveData<Either<Image, Int>> {
+        val liveData = MutableLiveData<Either<Image, Int>>()
 
         GlobalScope.launch {
             // Saves on database and gets the ID
@@ -53,9 +53,9 @@ open class LocalImageSource(private val imageDao: ImageDao, private val context:
                 imageDao.updateImage(image)
 
                 // Returns the updated image
-                liveData.postValue(ImageModel(updatedImage))
+                liveData.postValue(Either.Data(updatedImage))
             } else {
-                liveData.postValue(ImageModel(error = ERROR_INTERNAL_STORAGE))
+                liveData.postValue(Either.Error(ERROR_INTERNAL_STORAGE))
             }
         }
 
@@ -73,7 +73,7 @@ open class LocalImageSource(private val imageDao: ImageDao, private val context:
         }
     }
 
-    fun getLibrary(query: String?): LiveData<Either<List<Image>, Int>> {
+    override fun getLibrary(query: String?): LiveData<Either<List<Image>, Int>> {
         val liveData = MutableLiveData<Either<List<Image>, Int>>()
 
         GlobalScope.launch {
@@ -98,7 +98,7 @@ open class LocalImageSource(private val imageDao: ImageDao, private val context:
         return liveData
     }
 
-    fun deleteImage(image: Image): LiveData<Either<List<Image>, Int>> {
+    override fun deleteImage(image: Image): LiveData<Either<List<Image>, Int>> {
         val liveData = MutableLiveData<Either<List<Image>, Int>>()
 
         GlobalScope.launch {


### PR DESCRIPTION
## Description

`ImageRepository` doesn't need to know about a concrete implementation of a source. I've added an abstraction layer for letting the repository handle any tipe of `LocalImageSource` and `NetworkImageSource`. 

## Changes

* `LocalImageSource` is now an interface defining behavior for a local source
* `NetworkImageSource` is now an interface defining behavior for a network source
* Added `RoomImageSource` which is an implementation of `LocalImageSource` and defines behavior for getting images from a local source using a database with Room API
* Added `networkImageSource` which is an implementation of `NetworkImageSource` and defines behavior for getting images from a network source using an AsyncTask and URL connection which downloades the image.